### PR TITLE
fix a bug of rest()

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -335,12 +335,14 @@ fn builtin_rest(parameters: Vec<Object>) -> Object {
     }
 
     if let Object::ArrayObject(ao) = &parameters[0] {
-        if ao.elements.len() > 1 {
-            return Object::new_array(&ao.elements[1..].to_vec());
+        if ao.elements.len() != 0 {
+            Object::new_array(&ao.elements[1..].to_vec())
+        } else {
+            Object::Null
         }
+    } else {
+        Object::Null
     }
-
-    Object::Null
 }
 
 /// builtin function "push"

--- a/tests/test_evaluator.rs
+++ b/tests/test_evaluator.rs
@@ -801,6 +801,10 @@ fn test_builtin_functions() {
         },
         Test {
             input: r##"rest(rest(rest(rest([1, 2, 3, 4]))));"##,
+            expected: TestLiteral::ArrayLiteral { array: vec![] },
+        },
+        Test {
+            input: r##"rest(rest(rest(rest(rest([1, 2, 3, 4])))));"##,
             expected: TestLiteral::NullLiteral,
         },
         Test {
@@ -812,6 +816,46 @@ fn test_builtin_functions() {
                     TestLiteral::IntegerLiteral { value: 3 },
                 ],
             },
+        },
+        Test {
+            input: r##"let map = fn(arr, f) {
+                         let iter = fn(arr, accumulated) {
+                           if (len(arr) == 0) {
+                             accumulated
+                          } else {
+                            iter(rest(arr), push(accumulated, f(first(arr))));
+                          }
+                        };
+                        iter(arr, []);
+                      };
+                      let a = [1, 2, 3, 4];
+                      let double = fn(x) { x * 2 };
+                      map(a, double);"##,
+            expected: TestLiteral::ArrayLiteral {
+                array: vec![
+                    TestLiteral::IntegerLiteral { value: 2 },
+                    TestLiteral::IntegerLiteral { value: 4 },
+                    TestLiteral::IntegerLiteral { value: 6 },
+                    TestLiteral::IntegerLiteral { value: 8 },
+                ],
+            },
+        },
+        Test {
+            input: r##"let reduce = fn(arr, initial, f) {
+                         let iter = fn(arr, result) {
+                           if (len(arr) == 0) {
+                             result
+                           } else {
+                             iter(rest(arr), f(result, first(arr)));
+                           }
+                         };
+                         iter(arr, initial);
+                       };
+                       let sum = fn(arr) {
+                         reduce(arr, 0, fn(initial, el) { initial + el });
+                       };
+                       sum([1, 2, 3, 4, 5]);"##,
+            expected: TestLiteral::IntegerLiteral { value: 15 },
         },
     ];
 


### PR DESCRIPTION
rest() returned Null instead of [] for an array with only one element

* wrong

```
>> rest([1])
(null)
```

* correct

```
>> rest([1])
[]
```