### PR TITLE
fix warning about deprecated range pattern

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -65,7 +65,7 @@ impl Lexer {
                 }
                 Token::new(TokenType::StringToken, &self.input[p..self.position.get()])
             }
-            'a'...'z' | 'A'...'Z' | '_' => {
+            'a'..='z' | 'A'..='Z' | '_' => {
                 let p = self.position.get();
                 while self.ch.get().is_ascii_alphabetic() || self.ch.get() == '_' {
                     self.read_char();
@@ -73,7 +73,7 @@ impl Lexer {
                 let v = &self.input[p..self.position.get()];
                 return Token::new(lookup_ident(v), v); // don't need to read char more
             }
-            '0'...'9' => {
+            '0'..='9' => {
                 let p = self.position.get();
                 while self.ch.get().is_ascii_digit() {
                     self.read_char();


### PR DESCRIPTION
This fixes the following warnings appeared at the nightly channel.

```
warning: `...` range patterns are deprecated
  --> src/lexer.rs:68:16                                      
   |                                  
68 |             'a'...'z' | 'A'...'Z' | '_' => {                          
   |                ^^^ help: use `..=` for an inclusive range
   |                                                                                    
   = note: #[warn(ellipsis_inclusive_range_patterns)] on by default
                                             
warning: `...` range patterns are deprecated 
  --> src/lexer.rs:68:28                     
   |                                                                                
68 |             'a'...'z' | 'A'...'Z' | '_' => {
   |                            ^^^ help: use `..=` for an inclusive range 
                                                             
warning: `...` range patterns are deprecated                                           
  --> src/lexer.rs:76:16                   
   |                                    
76 |             '0'...'9' => {            
   |                ^^^ help: use `..=` for an inclusive range
                                                                          
warning: `...` range patterns are deprecated                               
```