### PR TITLE
remove Null from `ExpressionNode`, and use Option<ExpressionNode>, instead

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -25,7 +25,6 @@ pub enum ExpressionNode {
     CallExpressionNode(Box<CallExpression>),
     ArrayLiteralNode(Box<ArrayLiteral>),
     IndexExpressionNode(Box<IndexExpression>),
-    Null,
 }
 
 /// operation precedence

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -149,7 +149,6 @@ fn eval_expression_node(node: &ExpressionNode, env: Rc<Environment>) -> Object {
             }
             return Object::new_array(&elements);
         }
-        _ => panic!("not implemented yet: {:#?}", node),
     }
 }
 


### PR DESCRIPTION
enumの `ExpressionNode` から、 `Null` を廃止して `Option<ExpressionNode>` を使うように変更。