### PR TITLE
fix clippy warning

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -323,11 +323,7 @@ fn eval_hash_index_expression(hash: &Hash, key: &Object) -> Object {
 
 /// check if error or not
 fn is_error(obj: &Object) -> bool {
-    if let Object::ErrorObject(_) = obj {
-        true
-    } else {
-        false
-    }
+    matches!(obj, Object::ErrorObject(_))
 }
 
 /// apply function


### PR DESCRIPTION
fix the following warning

```
warning: if let .. else expression looks like `matches!` macro
   --> src/evaluator.rs:326:5
    |
326 | /     if let Object::ErrorObject(_) = obj {
327 | |         true
328 | |     } else {
329 | |         false
330 | |     }
    | |_____^ help: try this: `matches!(obj, Object::ErrorObject(_))`
    |
    = note: `#[warn(clippy::match_like_matches_macro)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro

warning: 1 warning emitted
```